### PR TITLE
Fix database reference to avoid None web cache errors

### DIFF
--- a/backend/services/web.py
+++ b/backend/services/web.py
@@ -1,14 +1,16 @@
 import httpx
-from services.db import db
+from services import db as db_service
 UA={"User-Agent":"Mozilla/5.0 (SimilarVendors/1.0)"}
 async def fetch(url: str, cache: bool = True) -> str:
-    if cache:
-        doc = await db.web_cache.find_one({"url": url})
+    db_instance = db_service.db
+    use_cache = cache and db_instance is not None
+    if use_cache:
+        doc = await db_instance.web_cache.find_one({"url": url})
         if doc and "html" in doc: return doc["html"]
     async with httpx.AsyncClient(timeout=30, headers=UA) as c:
         r = await c.get(url, follow_redirects=True)
         r.raise_for_status()
         html = r.text
-    if cache:
-        await db.web_cache.update_one({"url": url},{"$set":{"html":html}}, upsert=True)
+    if use_cache:
+        await db_instance.web_cache.update_one({"url": url},{"$set":{"html":html}}, upsert=True)
     return html


### PR DESCRIPTION
## Summary
- import the database service module so that init_db updates are visible in the FastAPI app and web fetch helper
- guard API routes and caching logic against an uninitialised database handle

## Testing
- python -m compileall .
