### PR TITLE
Add certifi CA bundle for MongoDB TLS connections

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,4 @@ langgraph==0.2.18
 langchain-core==0.2.41
 langchain-openai==0.1.24
 openai==1.51.0
+certifi==2024.8.30

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -1,12 +1,34 @@
 import os
+
+import certifi
 from motor.motor_asyncio import AsyncIOMotorClient
+
+
 MONGO_URI = os.getenv("MONGO_URI", "mongodb://localhost:27017")
 DB_NAME = os.getenv("MONGO_DB", "sv_langgraph")
 client = None
 db = None
+
+
+def _requires_tls_ca(uri: str) -> bool:
+    """Return True when the connection string implies TLS is required."""
+
+    uri_lower = uri.lower()
+    if uri_lower.startswith("mongodb+srv://"):
+        return True
+
+    tls_indicators = ("tls=true", "tls=1", "ssl=true", "ssl=1")
+    return any(indicator in uri_lower for indicator in tls_indicators)
+
+
 async def init_db():
     global client, db
-    client = AsyncIOMotorClient(MONGO_URI)
+
+    client_kwargs = {}
+    if _requires_tls_ca(MONGO_URI):
+        client_kwargs["tlsCAFile"] = certifi.where()
+
+    client = AsyncIOMotorClient(MONGO_URI, **client_kwargs)
     db = client[DB_NAME]
-    await db.runs.create_index([("kind",1),("_id",-1)])
-    await db.web_cache.create_index([("url",1)], unique=True)
+    await db.runs.create_index([("kind", 1), ("_id", -1)])
+    await db.web_cache.create_index([("url", 1)], unique=True)


### PR DESCRIPTION
## Summary
- load certifi and use its CA bundle when the MongoDB connection string indicates TLS
- add certifi to the backend dependencies so the bundle is available at runtime

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68d386cebc3083218e1091401fae269d