### PR TITLE
Fix serialization of HttpUrl when invoking graph

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -22,9 +22,10 @@ async def health():
 
 @app.post("/api/similar")
 async def similar(req: SimilarVendorsRequest):
+    payload = req.model_dump(mode="json")
     try:
-        result = await run_graph(req.dict())
-        doc = {"kind":"similar_vendors","input": req.dict(),"output": result,"created_at": datetime.now(timezone.utc).isoformat()}
+        result = await run_graph(payload)
+        doc = {"kind":"similar_vendors","input": payload,"output": result,"created_at": datetime.now(timezone.utc).isoformat()}
         if db_service.db is None:
             raise RuntimeError("Database not initialized")
         await db_service.db.runs.insert_one(doc)


### PR DESCRIPTION
## Summary
- normalize the incoming request payload to JSON-friendly data before executing the graph
- reuse the normalized payload when persisting runs to avoid non-serializable Url objects

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68d3884cb08c8321858f0e8be73be24a